### PR TITLE
Increase pylint score

### DIFF
--- a/_scripts/remove-stale-endpoints.py
+++ b/_scripts/remove-stale-endpoints.py
@@ -106,7 +106,7 @@ def api_check(folder: str, apis: dict) -> list[str]:
 def main():
     to_check: list[str, dict[str, str]] = []
 
-    for _, folder in enumerate(folders):
+    for folder in folders:
         if folder in IGNORE_FOLDERS + IGNORE_CHAINS:
             continue
 

--- a/_scripts/remove-stale-endpoints.py
+++ b/_scripts/remove-stale-endpoints.py
@@ -36,16 +36,16 @@ TIMEOUT_SECONDS = 10
 
 # endpoint_type == 'rpc' or 'rest'
 def remove_endpoint(folder: str, endpoint_url, endpoint_type: str, iter_num: int = 0):
-    chain_dir = os.path.join(parent_dir, folder, f"chain.json")
+    chain_dir = os.path.join(parent_dir, folder, "chain.json")
 
     if iter_num > 25:
         print(f"ISSUE: {folder} {endpoint_type} {endpoint_url}")
         return
 
-    with open(chain_dir, "r") as f:
+    with open(chain_dir, "r", encoding="utf-8") as f:
         try:
             chain_data = json.load(f)
-        except Exception as e:
+        except json.JSONDecodeError:
             # multiprocessing 'patch'
             time.sleep(rand.uniform(0.1, 5.0))
             remove_endpoint(folder, endpoint_url, endpoint_type, iter_num + 1)
@@ -66,7 +66,7 @@ def remove_endpoint(folder: str, endpoint_url, endpoint_type: str, iter_num: int
     ]
     chain_data["apis"] = apis
 
-    with open(chain_dir, "w") as f:
+    with open(chain_dir, "w", encoding="utf-8") as f:
         json.dump(chain_data, f, indent=2, ensure_ascii=False)
 
 
@@ -89,7 +89,7 @@ def do_last_time(folder, _type, addr, last_time_endpoints):
 
 def api_check(folder: str, apis: dict) -> list[str]:
     tasks = []
-    res = requests.get(f"https://status.cosmos.directory/{folder}").json()
+    res = requests.get(f"https://status.cosmos.directory/{folder}", timeout=2_000).json()
 
     for _type in ["rpc", "rest"]:
         last_time_endpoints = res[_type]["current"]
@@ -106,7 +106,7 @@ def api_check(folder: str, apis: dict) -> list[str]:
 def main():
     to_check: list[str, dict[str, str]] = []
 
-    for idx, folder in enumerate(folders):
+    for _, folder in enumerate(folders):
         if folder in IGNORE_FOLDERS + IGNORE_CHAINS:
             continue
 
@@ -114,11 +114,12 @@ def main():
         if not os.path.exists(path):
             continue
 
-        try:
-            apis: dict = json.loads(open(path).read())
-        except Exception:
-            print(f"[!] {folder} chain.json issue")
-            continue
+        with open(path, "r", encoding="utf-8") as f:
+            try:
+                apis: dict = json.loads(f.read())
+            except json.JSONDecodeError:
+                print(f"[!] {folder} chain.json issue")
+                continue
 
         apis = apis.get("apis", {})  # rpc, rest, grpc
 


### PR DESCRIPTION
Increasing pylint score from 7.90 to 9.15 (+1.25). Addressed:
- R1732: Consider using 'with' for resource-allocating operations (consider-using-with)
- W0612: Unused variable 'e' (unused-variable)
- W0612: Unused variable 'idx' (unused-variable)
- W0718: Catching too general exception Exception (broad-exception-caught)
- W1309: Using an f-string that does not have any interpolated variables (f-string-without-interpolation)
- W1514: Using open without explicitly specifying an encoding (unspecified-encoding)


--- 

Before changes:

```
❯ pylint **/*.py
************* Module remove-stale-endpoints
_scripts/remove-stale-endpoints.py:1:0: C0114: Missing module docstring (missing-module-docstring)
_scripts/remove-stale-endpoints.py:1:0: C0103: Module name "remove-stale-endpoints" doesn't conform to snake_case naming style (invalid-name)
_scripts/remove-stale-endpoints.py:38:0: C0116: Missing function or method docstring (missing-function-docstring)
_scripts/remove-stale-endpoints.py:39:49: W1309: Using an f-string that does not have any interpolated variables (f-string-without-interpolation)
_scripts/remove-stale-endpoints.py:45:9: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
_scripts/remove-stale-endpoints.py:48:15: W0718: Catching too general exception Exception (broad-exception-caught)
_scripts/remove-stale-endpoints.py:69:9: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
_scripts/remove-stale-endpoints.py:48:8: W0612: Unused variable 'e' (unused-variable)
_scripts/remove-stale-endpoints.py:73:0: C0116: Missing function or method docstring (missing-function-docstring)
_scripts/remove-stale-endpoints.py:86:15: W0718: Catching too general exception Exception (broad-exception-caught)
_scripts/remove-stale-endpoints.py:90:0: C0116: Missing function or method docstring (missing-function-docstring)
_scripts/remove-stale-endpoints.py:92:10: W3101: Missing timeout argument for method 'requests.get' can cause your program to hang indefinitely (missing-timeout)
_scripts/remove-stale-endpoints.py:106:0: C0116: Missing function or method docstring (missing-function-docstring)
_scripts/remove-stale-endpoints.py:119:15: W0718: Catching too general exception Exception (broad-exception-caught)
_scripts/remove-stale-endpoints.py:118:36: R1732: Consider using 'with' for resource-allocating operations (consider-using-with)
_scripts/remove-stale-endpoints.py:118:36: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
_scripts/remove-stale-endpoints.py:109:8: W0612: Unused variable 'idx' (unused-variable)

------------------------------------------------------------------
Your code has been rated at 7.90/10
```

after these changes:

```
❯ pylint **/*.py
************* Module remove-stale-endpoints
_scripts/remove-stale-endpoints.py:1:0: C0114: Missing module docstring (missing-module-docstring)
_scripts/remove-stale-endpoints.py:1:0: C0103: Module name "remove-stale-endpoints" doesn't conform to snake_case naming style (invalid-name)
_scripts/remove-stale-endpoints.py:38:0: C0116: Missing function or method docstring (missing-function-docstring)
_scripts/remove-stale-endpoints.py:73:0: C0116: Missing function or method docstring (missing-function-docstring)
_scripts/remove-stale-endpoints.py:86:15: W0718: Catching too general exception Exception (broad-exception-caught)
_scripts/remove-stale-endpoints.py:90:0: C0116: Missing function or method docstring (missing-function-docstring)
_scripts/remove-stale-endpoints.py:106:0: C0116: Missing function or method docstring (missing-function-docstring)

------------------------------------------------------------------
Your code has been rated at 9.15/10 (previous run: 7.90/10, +1.25)
```